### PR TITLE
Fix NullPointerException on account DELETE

### DIFF
--- a/gamify-impl/src/main/java/ch/heigvd/gamify/ui/api/endpoints/AccountController.java
+++ b/gamify-impl/src/main/java/ch/heigvd/gamify/ui/api/endpoints/AccountController.java
@@ -36,8 +36,12 @@ public class AccountController implements AccountApi {
   @Override
   public ResponseEntity<Void> deleteAccount() {
     var app = (App) request.getAttribute(BasicAuthFilter.APP_KEY);
-    if (app != null &&
-        repository.findByNameAndPassword(app.getName(), app.getPassword()).isPresent()) {
+
+    if (app == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    if (repository.findByNameAndPassword(app.getName(), app.getPassword()).isPresent()) {
       repository.delete(app);
       return ResponseEntity.noContent().build();
     } else {

--- a/gamify-impl/src/main/java/ch/heigvd/gamify/ui/api/endpoints/AccountController.java
+++ b/gamify-impl/src/main/java/ch/heigvd/gamify/ui/api/endpoints/AccountController.java
@@ -36,7 +36,8 @@ public class AccountController implements AccountApi {
   @Override
   public ResponseEntity<Void> deleteAccount() {
     var app = (App) request.getAttribute(BasicAuthFilter.APP_KEY);
-    if (repository.findByNameAndPassword(app.getName(), app.getPassword()).isPresent()) {
+    if (app != null &&
+        repository.findByNameAndPassword(app.getName(), app.getPassword()).isPresent()) {
       repository.delete(app);
       return ResponseEntity.noContent().build();
     } else {


### PR DESCRIPTION
If a user was attempting to DELETE an account while not being authenticated with HTTP Basic, a `NullPointerException` would be thrown instead of returning an HTTP error code.